### PR TITLE
fix for #17

### DIFF
--- a/Slash/Apache/User/User.pm
+++ b/Slash/Apache/User/User.pm
@@ -100,10 +100,14 @@ sub handler {
 	add_random_quote($r);
 
 	# let pass unless / or .pl
-	if ($gSkin->{rootdir}) {
-		my $path = URI->new($gSkin->{rootdir})->path;
-		$uri =~ s/^\Q$path//;
-	}
+	#
+	# MC: This seems broken; if we don't deal with cookies
+	# on every page, we get inconsistent behavior *at best*
+	#
+	#if ($gSkin->{rootdir}) {
+	#	my $path = URI->new($gSkin->{rootdir})->path;
+	#	$uri =~ s/^\Q$path//;
+	#}
 
 	my $is_ssl = Slash::Apache::ConnectionIsSSL();
 

--- a/Slash/Utility/Data/Data.pm
+++ b/Slash/Utility/Data/Data.pm
@@ -3446,6 +3446,7 @@ sub parseDomainTags {
 	return '' if !defined($html) || $html eq '';
 
 	my $user = getCurrentUser();
+	my $form = getCurrentForm();
 
 	# The default is 2 ("always show");  note this default is enforced in
 	# prepareUser().  Note also that if I were being smart I'd use
@@ -3459,9 +3460,12 @@ sub parseDomainTags {
 			$udt == 1		# the user leaves it up to us
 			&& $recommended		# and we think the poster has earned tagless posting
 		);
-	$want_tags = 1 if $ENV{SCRIPT_NAME} eq '/admin.pl';
-	$want_tags = 1 if $ENV{SCRIPT_NAME} eq '/submit.pl' && $user->{is_admin};
-
+		
+	unless ($form->{cchp}) {	
+		$want_tags = 1 if $ENV{SCRIPT_NAME} eq '/admin.pl';
+		$want_tags = 1 if $ENV{SCRIPT_NAME} eq '/submit.pl' && $user->{is_admin};
+	}
+	
 	if ($want_tags && !$notags) {
 		$html =~ s{</a ([^<>]+)>}{</a> [$1]}gi;
 	} else {

--- a/Slash/Utility/System/System.pm
+++ b/Slash/Utility/System/System.pm
@@ -55,6 +55,7 @@ our @EXPORT  = qw(
 	doLogExit
 	save2file
 	prog2file
+	prog2nofile
 	makeDir
 );
 our @EXPORT_OK = qw();

--- a/themes/default/htdocs/article.pl
+++ b/themes/default/htdocs/article.pl
@@ -170,9 +170,6 @@ sub main {
 		my $return_url ="";
 		$return_url = "//".$ENV{HTTP_HOST}.$ENV{REQUEST_URI} unless $form->{cchp};
 		
-		
-		my $return_url = "//".$ENV{HTTP_HOST}.$ENV{REQUEST_URI};
-		
 		slashDisplay('display', {
 			poll			=> $pollbooth,
 			section			=> $SECT,

--- a/themes/default/htdocs/article.pl
+++ b/themes/default/htdocs/article.pl
@@ -167,6 +167,10 @@ sub main {
 			}
 		}
 		
+		my $return_url ="";
+		$return_url = "//".$ENV{HTTP_HOST}.$ENV{REQUEST_URI} unless $form->{cchp};
+		
+		
 		my $return_url = "//".$ENV{HTTP_HOST}.$ENV{REQUEST_URI};
 		
 		slashDisplay('display', {

--- a/themes/default/tasks/freshenup.pl
+++ b/themes/default/tasks/freshenup.pl
@@ -189,7 +189,7 @@ $task{$me}{code} = sub {
 	}
 
 	############################################################
-	# get cc and hp  for stories
+	# get commentcount and hitparade for stories
 	############################################################
 
 	# Freshen the static versions of any stories that have changed.
@@ -424,30 +424,6 @@ sub _read_and_unlink_cchp_file {
 	}
 	unlink $cchp_file;
 	return($cc, $hp);
-}
-
-sub gen_firehose_static {
-	my($vu, $filename, $section, $skinname, $opts) = @_;
-	my $constants = getCurrentStatic();
-	my $fargs = "virtual_user=$vu taskgen=1 section='$section'";
-	my $basedir = $constants->{basedir};
-	$skinname .= "/" if $skinname;
-
-	foreach (keys %$opts) {
-		$fargs .= " $_=$opts->{$_}";
-	}
-	$fargs .= " anonval=$constants->{firehose_anonval_param}" if $constants->{firehose_anonval_param};
-	slashdLog("$vu $filename $section $fargs");
-	$filename ||= "firehose.shtml";
-
-	prog2file(
-		"$basedir/firehose.pl",
-		"$basedir/$skinname/$filename", {
-			args => $fargs,
-			verbosity => verbosity(),
-			handle_err => 0
-
-	});
 }
 
 1;


### PR DESCRIPTION
Fixed slashd freshenup.pl task by adding back in some code.  Created new prog2nofile to have article.pl run and do the comment count and hit parade stuff that freshenup.pl needed.  It still writes the cchp data to a file, but its a temp file deleted after use, and this was easier to setup than doing it all dynamically.

Removed some errors that this task threw up by checking if cchp was one of the form vars.  

Also reverted a push that TMB made to User.pm.