### PR TITLE
fixes for issue #19 (broken Nexus support)

### DIFF
--- a/Slash/Apache/Apache.pm
+++ b/Slash/Apache/Apache.pm
@@ -514,20 +514,20 @@ sub IndexHandler  {
 	my @bits = split ('/', $proper_uri->path);
 
 	# Only handle this if we have at least *2* segments
-	if ( (scalar @bits) ge 2) {
+	# if ( (scalar @bits) ge 2) {
 		# we've got a live one!
 
 		# this should probably be cached ...
 		my $skins = $slashdb->getSkins();
 
 		for my $skin (keys %$skins) {
-			if ($skins->{$skin}{name} eq $bits[1]) {
+			if ($skins->{$skin}{name} eq $bits[0]) {
 				my $actual_file = $bits[-1];
 				$r->filename("$basedir/$actual_file");
 				return OK;
 			}
 		}
-	}
+	# }
 
 	return DECLINED;
 }

--- a/Slash/Apache/Apache.pm
+++ b/Slash/Apache/Apache.pm
@@ -432,6 +432,7 @@ sub IndexHandler  {
 		}
 	}
 
+	# Remove base rootdir path from uri so that all nexuses behave as mainpage.
 	if ($gSkin->{rootdir}) {
 		my $path = URI->new($gSkin->{rootdir})->path;
 		$uri =~ s/^\Q$path//;

--- a/Slash/Apache/Apache.pm
+++ b/Slash/Apache/Apache.pm
@@ -514,20 +514,20 @@ sub IndexHandler  {
 	my @bits = split ('/', $proper_uri->path);
 
 	# Only handle this if we have at least *2* segments
-	# if ( (scalar @bits) ge 2) {
+	if ( (scalar @bits) ge 2) {
 		# we've got a live one!
 
 		# this should probably be cached ...
 		my $skins = $slashdb->getSkins();
 
 		for my $skin (keys %$skins) {
-			if ($skins->{$skin}{name} eq $bits[0]) {
+			if ($skins->{$skin}{name} eq $bits[1]) {
 				my $actual_file = $bits[-1];
 				$r->filename("$basedir/$actual_file");
 				return OK;
 			}
 		}
-	# }
+	}
 
 	return DECLINED;
 }

--- a/Slash/Utility/Anchor/Anchor.pm
+++ b/Slash/Utility/Anchor/Anchor.pm
@@ -151,13 +151,15 @@ sub header {
 		return if $r->header_only;
 	}
 
-	my $skid = 0;
-	if ($skin_name) {
-		my $skin = $slashdb->getSkin($skin_name);
-		$skid = $skin->{skid} if $skin;
-	}
-#print STDERR scalar(localtime) . " $$ header skin_name='$skin_name' skid='$skid' det='" . determineCurrentSkin() . "'\n";
-	setCurrentSkin($skid || determineCurrentSkin());
+	#  gSkin is set during PerlTransHandler step by Slash::Apache sub IndexHandler --paulej72
+	#my $skid = 0;
+	#if ($skin_name) {
+	#	my $skin = $slashdb->getSkin($skin_name);
+	#	$skid = $skin->{skid} if $skin;
+	#}
+	#print STDERR scalar(localtime) . " $$ header skin_name='$skin_name' skid='$skid' det='" . determineCurrentSkin() . "'\n";
+	
+	#setCurrentSkin($skid || determineCurrentSkin());
 	getSkinColors();
 
 	# This is ALWAYS displayed. Let the template handle the title

--- a/Slash/Utility/Environment/Environment.pm
+++ b/Slash/Utility/Environment/Environment.pm
@@ -3042,7 +3042,7 @@ sub determineCurrentSkin {
 		$hostname =~ s/:\d+$//;
 
 		# could probably do this faster with a regex but ..
-	        my $uri = URI->new($r->uri);
+		my $uri = URI->new($r->uri);
 		my @bits = split ('/', $uri->path);
 
 		# MC: skins can come in two forms, either as a hostname, or as a nexus name. Nexus names have no periods
@@ -3053,7 +3053,7 @@ sub determineCurrentSkin {
 		# First see if we can retrieve by name ...
 		($skin) = grep {
 				my $tmp = lc $skins->{$_}{name} || ''; 
-				$tmp eq lc $bits[1];
+				$tmp eq lc $bits[0];
 			} sort { $a <=> $b } keys %$skins;
 
 		# Nope, fall back to hostname

--- a/Slash/Utility/Environment/Environment.pm
+++ b/Slash/Utility/Environment/Environment.pm
@@ -3053,7 +3053,7 @@ sub determineCurrentSkin {
 		# First see if we can retrieve by name ...
 		($skin) = grep {
 				my $tmp = lc $skins->{$_}{name} || ''; 
-				$tmp eq lc $bits[0];
+				$tmp eq lc $bits[1];
 			} sort { $a <=> $b } keys %$skins;
 
 		# Nope, fall back to hostname

--- a/plugins/Search/search.pl
+++ b/plugins/Search/search.pl
@@ -36,7 +36,7 @@ sub main {
 	my $constants = getCurrentStatic();
 	my $form      = getCurrentForm();
 	my $user      = getCurrentUser();
-	setCurrentSkin(determineCurrentSkin());
+#	setCurrentSkin(determineCurrentSkin());
 	my $gSkin     = getCurrentSkin();
 	my $slashdb   = getCurrentDB();
 	my $searchDB  = getObject('Slash::Search', { db_type => 'search' });

--- a/themes/default/htdocs/article.pl
+++ b/themes/default/htdocs/article.pl
@@ -34,13 +34,14 @@ sub main {
 		&& !($form->{ssi} && $form->{ssi} eq "yes")) {
 		# Make sure the reader is viewing this story in the
 		# proper skin.
-		my $cur_skid = determineCurrentSkin();
+#		my $cur_skid = determineCurrentSkin(); #broken now, but may be fixed
+		my $cur_skid = $gSkin->{skid};
 		if ($story->{primaryskid} != $cur_skid) {
 			my $cur_skin = $reader->getSkin($cur_skid);
 			my $story_skin = $reader->getSkin($story->{primaryskid});
 			if ($story_skin && $story_skin->{rootdir}
 				&& $story_skin->{rootdir} ne $cur_skin->{rootdir}) {
-				redirect("$story_skin->{rootdir}$ENV{REQUEST_URI}");
+				redirect("$story_skin->{rootdir}/article.pl?$ENV{QUERY_STRING}");
 				return;
 			}
 		}

--- a/themes/default/htdocs/comments.pl
+++ b/themes/default/htdocs/comments.pl
@@ -179,18 +179,19 @@ sub main {
 
 	$form->{pid} ||= "0";
 
+	# Not needed --paulej72 20150427
 	# this is so messed up ... it's done again under header(), but
 	# sometimes we need it done before header() is called, because,
 	# like i said, this is so messed up ...
-	{
-		my $skid;
-		if ($section) {
-			my $skin = $slashdb->getSkin($section);
-			$skid = $skin->{skid} if $skin;
-		}
-		setCurrentSkin($skid || determineCurrentSkin());
-		Slash::Utility::Anchor::getSkinColors();
-	}
+	#{
+	#	my $skid;
+	#	if ($section) {
+	#		my $skin = $slashdb->getSkin($section);
+	#		$skid = $skin->{skid} if $skin;
+	#	}
+	#	setCurrentSkin($skid || determineCurrentSkin());
+	#	Slash::Utility::Anchor::getSkinColors();
+	#}
 
 
 	# If this is a comment post, we can't write the header yet,

--- a/themes/default/htdocs/index.pl
+++ b/themes/default/htdocs/index.pl
@@ -276,7 +276,7 @@ my $start_time = Time::HiRes::time;
 	);
 
 	my $title = getData('head', { skin => $skin_name });
-	header({ title => $title, link => $linkrel }) or return;
+	header({ title => $title, link => $linkrel }, $skin_name) or return;
 
 	if ($form->{remark}
 		&& $user->{is_subscriber}

--- a/themes/default/templates/printCommentsMain;misc;default
+++ b/themes/default/templates/printCommentsMain;misc;default
@@ -20,15 +20,16 @@ __name__
 printCommentsMain
 __template__
 [% stripped_title = title | strip_title %]
+[% stripped_link = link | strip_urlattr %]
 [% IF parent.type == 'journal' %]
-	[% PROCESS titlebar title="$stripped_title" %]
+	[% PROCESS titlebar title="<a href=\"$stripped_link\">$stripped_title</a>" %]
 	<div class="generalbody">
 		[% parent.content %]
 	</div>
 [% END %]
 [% IF parent.type == 'story' %]
 <div class="article">
-	[% PROCESS titlebar title="$stripped_title" %]
+	[% PROCESS titlebar title="<a href=\"$stripped_link\">$stripped_title</a>" %]
 	[% IF parent.story %]
 		<div class="details">
 		[% IF parent.story.by %]


### PR DESCRIPTION
since example.com/nexus style of urls for nexuses breaks determineCurrentSkin if called more than once per page because the uri is rewritten in IndexHandler, I removed all other calls to deermineCurrentSkin from other parts of the code.  gSkin will be set and should stay around if all other parts of the code are working.

also cleaned up IndexHandler to remove code that did nothing and to fix up the nexus redirects.