### PR TITLE
Removes &from=rss from feed urls since we don't track it and it bugs some folks

### DIFF
--- a/Slash/XML/RSS/RSS.pm
+++ b/Slash/XML/RSS/RSS.pm
@@ -400,7 +400,7 @@ sub rss_story {
 		my $linktitle = $story->{title};
 		$linktitle =~ s/\s+/-/g;
 		$linktitle =~ s/[^A-Za-z0-9\-]//g;
-		$action = "article.pl?sid=$story->{sid}&from=rss";
+		$action = "article.pl?sid=$story->{sid}";
 
 
 		if ($story->{primaryskid}) {
@@ -440,7 +440,7 @@ sub rss_story {
 			my $extra = '';
 			# If the text of the <img src>'s query string changes,
 			# Stats.pm getTopBadgeURLs() may also have to change.
-			$extra .= qq{<p><a href="$action"><img src="$channel->{'link'}slashdot-it.pl?from=rss&amp;op=image&amp;style=h0&amp;sid=$story->{sid}"></a></p>}
+			$extra .= qq{<p><a href="$action"><img src="$channel->{'link'}slashdot-it.pl?op=image&amp;style=h0&amp;sid=$story->{sid}"></a></p>}
 				if $constants->{rdfbadge};
 			$extra .= "<p><a href=\"$action\">Read more of this story</a> at $constants->{sitename}.</p>"
 				if $action;

--- a/plugins/PollBooth/templates/pollbooth;misc;default
+++ b/plugins/PollBooth/templates/pollbooth;misc;default
@@ -66,7 +66,7 @@ __template__
 				<p><b>[% question | strip_title %]</b></p>
 				<ul>
 					[% FOREACH ans = answers %]
-						<li><input type="radio" name="aid" value="[% ans.aid | strip_attribute %]">[% IF fromrss %]<a href="[% gSkin.rootdir %]/pollBooth.pl?qid=[% qid %]&amp;aid=[% ans.aid %]&amp;reskey=[% rkey.reskey %]&from=rss">[% END %][% ans.answer | strip_title %][% IF fromrss %]</a>[% END %]</li>
+						<li><input type="radio" name="aid" value="[% ans.aid | strip_attribute %]">[% IF fromrss %]<a href="[% gSkin.rootdir %]/pollBooth.pl?qid=[% qid %]&amp;aid=[% ans.aid %]&amp;reskey=[% rkey.reskey %]">[% END %][% ans.answer | strip_title %][% IF fromrss %]</a>[% END %]</li>
 					[% END %]
 				</ul>
 				<p>


### PR DESCRIPTION
I don't have any idea why it bothers them but meh. If we used it for metrics or even regularly ran an access_log that might be another story.