### PR TITLE
Fix "Read the rest of this comment..." logic

### DIFF
--- a/Slash/DB/MySQL/MySQL.pm
+++ b/Slash/DB/MySQL/MySQL.pm
@@ -6391,9 +6391,10 @@ sub getCommentTextCached {
 		my $abbreviate = $abbreviate_ok && $comments->{$cid}{class} eq 'oneline';
 		my $original_text = $more_comment_text->{$cid};
 		my $this_max_len = $abbreviate ? $abbreviate_len : $max_len;
+		my $allowed_overrun = $abbreviate ? 256 : ($this_max_len * 0.20); #allow 256 char overrun for abbreviated mode or 20% for normal
 		if (	   $possible_chop
 			&& !($opt->{cid} && $opt->{cid} eq $cid)
-			&& ($comments->{$cid}{len} > ($this_max_len + 256))
+			&& ($comments->{$cid}{len} > ($this_max_len + $allowed_overrun))
 		) {
 			# We remove the domain tags so that strip_html will not
 			# consider </a blah> to be a non-approved tag.  We'll

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -1874,13 +1874,13 @@ sub dispComment {
 	my $user = getCurrentUser();
 	my $form = getCurrentForm();
 	my $gSkin = getCurrentSkin();
-	my $maxcommentsize = $options->{maxcommentsize} || $constants->{default_maxcommentsize};
+	my $maxcommentsize = $constants->{default_maxcommentsize};
 
 	my $comment_shrunk;
 
 	if ($form->{mode} ne 'archive'
 		&& !defined($comment->{abbreviated})
-		&& $comment->{len} > $maxcommentsize
+		&& $comment->{len} > ($maxcommentsize+256) #allow overrun of 256 chars as the trimming that happens in MySQL.pm also allows this
 		&& $form->{cid} ne $comment->{cid})
 	{
 		$comment_shrunk = 1;

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -1875,12 +1875,13 @@ sub dispComment {
 	my $form = getCurrentForm();
 	my $gSkin = getCurrentSkin();
 	my $maxcommentsize = $constants->{default_maxcommentsize};
+	my $allowed_overrun = $maxcommentsize * 0.20; #allow 20% overrun
 
 	my $comment_shrunk;
 
 	if ($form->{mode} ne 'archive'
 		&& !defined($comment->{abbreviated})
-		&& $comment->{len} > ($maxcommentsize+256) #allow overrun of 256 chars as the trimming that happens in MySQL.pm also allows this
+		&& $comment->{len} > ($maxcommentsize + $allowed_overrun) #check if comment length is past max size + overrun (trimming actually happens in MySQL.pm getCommentTextCached)
 		&& $form->{cid} ne $comment->{cid})
 	{
 		$comment_shrunk = 1;


### PR DESCRIPTION
Fix incorrect display of "Read the rest of this comment..." due to trimming function in DB/MySQL/MySQL.pm allowing a overrun but the display code in Utility/Comments/Comments.pm using a hard limit.

While fixing also changed from a 256 char overrun to 20% of limit feel free to tweak the percentage limit or go back to a fixed overrun.

Removed reading of $options->{maxcommentsize} in Utility/Comments/Comments.pm as the user setting isn't used in the trimming function so there was a potential for a mismatch.