### PR TITLE
Fix new Poll issue #52

### DIFF
--- a/sql/mysql/slashschema_create.sql
+++ b/sql/mysql/slashschema_create.sql
@@ -735,7 +735,7 @@ CREATE TABLE pollquestions (
 	question char(255) NOT NULL,
 	voters mediumint,
 	topic smallint UNSIGNED NOT NULL,
-	discussion mediumint UNSIGNED NOT NULL,
+	discussion mediumint UNSIGNED NULL,
 	date datetime,
 	uid mediumint UNSIGNED NOT NULL,
 	primaryskid SMALLINT UNSIGNED,

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -15,3 +15,6 @@ ALTER TABLE stories ADD COLUMN notes text;
 
 # New Rehash topic
 INSERT INTO topics (tid, keyword, textname, series, image, width, height, submittable) VALUES (25,'rehash', 'Rehash', 'no', 'topicrehash.png',112,36,'yes');
+
+# Fix Poll Insert
+ALTER TABLE pollquestions CHANGE discussion discussion mediumint UNSIGNED NULL;


### PR DESCRIPTION
A new Poll does not necessarily need a discussion, but MySQL column was set to NOT NULL for discussion in pollquestions.  Changed the default to NULL and all works.  

Logic works by inserting a new poll into the db then checking if it has or needs a discussion set after being created. Old versions of MySQL must have ignored that the column was set to NOT NULL on the insert.