### PR TITLE
Fix for Most Recent Journals Issue #46

### DIFF
--- a/sbin/portald
+++ b/sbin/portald
@@ -52,7 +52,7 @@ END {
 ################################################################################
 sub geturl {
 	my($url, $options) = @_;
-	my $ua = new LWP::UserAgent;
+	my $ua = new LWP::UserAgent(ssl_opts => { verify_hostname => 0 });
 	my $request = new HTTP::Request('GET', $url);
 	$ua->proxy(http => $constants->{http_proxy}) if $constants->{http_proxy};
 	my $timeout = 30;


### PR DESCRIPTION
LWP::UserAgent needed set to ignore ssl cert errors.  Also had to set sbindir to the correct value as it was set wrong and portald was not running.