### PR TITLE
make fuzzy length same in Comments.pm as in MySQL.pm (redo pull #53)

### DIFF
--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -1880,7 +1880,7 @@ sub dispComment {
 
 	if ($form->{mode} ne 'archive'
 		&& !defined($comment->{abbreviated})
-		&& $comment->{len} > $maxcommentsize
+		&& $comment->{len} > ($maxcommentsize + 256)
 		&& $form->{cid} ne $comment->{cid})
 	{
 		$comment_shrunk = 1;

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -1874,7 +1874,7 @@ sub dispComment {
 	my $user = getCurrentUser();
 	my $form = getCurrentForm();
 	my $gSkin = getCurrentSkin();
-	my $maxcommentsize = $options->{maxcommentsize} || $constants->{default_maxcommentsize};
+	my $maxcommentsize = $constants->{default_maxcommentsize};
 
 	my $comment_shrunk;
 


### PR DESCRIPTION
In sub getCommentTextCached, text is checked against $maxcommentsize + 256 to determine if a chop is needed, but it is chopped to $maxcommentsize.  To make the “Read more of this comment text” show up properly the $comment_shrunk should be triggered at the same point, or you will have comments that are not chopped that have the “Read more” text.