### PR TITLE
previous fix for sections template did not work

### DIFF
--- a/themes/default/templates/sections;misc;default
+++ b/themes/default/templates/sections;misc;default
@@ -14,20 +14,15 @@ __name__
 sections
 __template__
 <ul>
-	<li>
-		<a href="[% constants.rootdir %]/">[% constants.sitename %]</a>
-	</li>
-	[% skins = Slash.db.getSkins %]
-	
-	[% FOREACH skid IN skins.sort('title') %]
-		[% NEXT IF skid == constants.mainpage_skid %]
-		[% skins.skid.title %]
-		<li>
-			<a href="[% skins.$skid.rootdir %]/">[% skins.$skid.title %]</a>
-		</li>
+	<li><a href="[% constants.rootdir %]/">[% constants.sitename %]</a></li>
+
+	[% skins = Slash.db.getSkins;
+	skins.delete(constants.mainpage_skid) %]
+
+	[% FOREACH item IN skins.values.sort('title') %]
+		<li><a href="[% item.rootdir %]/">[% item.title %]</a></li>
 	[% END %]
 </ul>
-
 __seclev__
 10000
 __version__


### PR DESCRIPTION
Template fix seemed to work, but sort(‘title’) only works on lists not hashes.  So figured a way to just us the values from the skins hash by removing the mainpage skin from the list first.