### PR TITLE
Various installation corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,14 @@ SLASH_PREFIX = $(ENVIRONMENT_PREFIX)/rehash
 # If this isn't used anymore, can we remove it?
 INIT = /etc
 USER = nobody
-GROUP = nobody
+GROUP = nogroup
 CP = cp
 INSTALL = install
 UNAME = `uname`
 MAKE = make -s
 
 # Apache stuff
-APACHE_MIRROR=http://apache.osuosl.org/httpd
+APACHE_MIRROR=http://archive.apache.org/dist/httpd/
 APACHE_VER=2.2.29
 APACHE_DIR=httpd-$(APACHE_VER)
 APACHE_FILE=$(APACHE_DIR).tar.bz2
@@ -340,7 +340,7 @@ rpm :
 	rpm -ba slash.spec
 
 build-environment: stamp/apache-built stamp/perl-built stamp/mod-perl-built stamp/install-cpamn stamp/install-apache2-upload stamp/install-cache-memcached stamp/install-cache-memcached-fast stamp/install-data-javascript-anon stamp/install-date-calc stamp/install-date-format stamp/install-date-language stamp/install-date-parse stamp/install-datetime-format-mysql stamp/install-dbd-mysql stamp/install-digest-md5 stamp/install-email-valid stamp/install-gd stamp/install-gd-text-align stamp/install-html-entities stamp/install-html-formattext stamp/install-html-tagset stamp/install-html-tokeparser stamp/install-html-treebuilder stamp/install-http-request stamp/install-image-size stamp/install-javascript-minifier stamp/install-json stamp/install-lingua-stem stamp/install-lwp-parallel-useragent stamp/install-lwp-useragent stamp/install-mail-address stamp/install-mail-bulkmail  stamp/install-mail-sendmail stamp/install-mime-types stamp/install-mojo-server-daemon  stamp/install-net-ip stamp/install-net-server stamp/install-schedule-cron stamp/install-soap-lite stamp/install-sphinx-search stamp/install-uri-encode stamp/install-template stamp/install-xml-parser stamp/install-xml-parser-expat stamp/install-xml-rss stamp/append-apache-config
-	@echo "Setting permissions on the $(ENVIRONMENT_PREFIX) directory
+	@echo "Setting permissions on the $(ENVIRONMENT_PREFIX) directory"
 	chown $(USER):$(GROUP) -R $(ENVIRONMENT_PREFIX)
 	@echo ""
 	@echo "Rehash Environment Successfully Installed!"

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ pluginsandtagboxes:
 
 all: install
 
-install: slash pluginsandtagboxes
+install: stamp/append-apache-config slash pluginsandtagboxes
 
 	# Create all necessary directories.
 	$(INSTALL) -d \
@@ -339,7 +339,7 @@ manifest :
 rpm :
 	rpm -ba slash.spec
 
-build-environment: stamp/apache-built stamp/perl-built stamp/mod-perl-built stamp/install-cpamn stamp/install-apache2-upload stamp/install-cache-memcached stamp/install-cache-memcached-fast stamp/install-data-javascript-anon stamp/install-date-calc stamp/install-date-format stamp/install-date-language stamp/install-date-parse stamp/install-datetime-format-mysql stamp/install-dbd-mysql stamp/install-digest-md5 stamp/install-email-valid stamp/install-gd stamp/install-gd-text-align stamp/install-html-entities stamp/install-html-formattext stamp/install-html-tagset stamp/install-html-tokeparser stamp/install-html-treebuilder stamp/install-http-request stamp/install-image-size stamp/install-javascript-minifier stamp/install-json stamp/install-lingua-stem stamp/install-lwp-parallel-useragent stamp/install-lwp-useragent stamp/install-mail-address stamp/install-mail-bulkmail  stamp/install-mail-sendmail stamp/install-mime-types stamp/install-mojo-server-daemon  stamp/install-net-ip stamp/install-net-server stamp/install-schedule-cron stamp/install-soap-lite stamp/install-sphinx-search stamp/install-uri-encode stamp/install-template stamp/install-xml-parser stamp/install-xml-parser-expat stamp/install-xml-rss stamp/append-apache-config
+build-environment: stamp/apache-built stamp/perl-built stamp/mod-perl-built stamp/install-cpamn stamp/install-apache2-upload stamp/install-cache-memcached stamp/install-cache-memcached-fast stamp/install-data-javascript-anon stamp/install-date-calc stamp/install-date-format stamp/install-date-language stamp/install-date-parse stamp/install-datetime-format-mysql stamp/install-dbd-mysql stamp/install-digest-md5 stamp/install-email-valid stamp/install-gd stamp/install-gd-text-align stamp/install-html-entities stamp/install-html-formattext stamp/install-html-tagset stamp/install-html-tokeparser stamp/install-html-treebuilder stamp/install-http-request stamp/install-image-size stamp/install-javascript-minifier stamp/install-json stamp/install-lingua-stem stamp/install-lwp-parallel-useragent stamp/install-lwp-useragent stamp/install-mail-address stamp/install-mail-bulkmail  stamp/install-mail-sendmail stamp/install-mime-types stamp/install-mojo-server-daemon  stamp/install-net-ip stamp/install-net-server stamp/install-schedule-cron stamp/install-soap-lite stamp/install-sphinx-search stamp/install-uri-encode stamp/install-template stamp/install-xml-parser stamp/install-xml-parser-expat stamp/install-xml-rss
 	@echo "Setting permissions on the $(ENVIRONMENT_PREFIX) directory"
 	chown $(USER):$(GROUP) -R $(ENVIRONMENT_PREFIX)
 	@echo ""

--- a/sql/mysql/defaults.sql
+++ b/sql/mysql/defaults.sql
@@ -1114,7 +1114,7 @@ INSERT INTO vars (name, value, description) VALUES ('submissions_speed_limit','3
 INSERT INTO vars (name, value, description) VALUES ('submit_domains_invalid', 'example.com', 'space separated list of domains that are not valid for submitting stories');
 INSERT INTO vars (name, value, description) VALUES ('submit_categories','Back','Extra submissions categories');
 INSERT INTO vars (name, value, description) VALUES ('submit_extra_sort_key', '', 'Provides an additional submission list sorted on the given field name');
-INSERT INTO vars (name, value, discription) VALUES ('submit_keep_p',1,'Keep <p> tags in story submissions');
+INSERT INTO vars (name, value, description) VALUES ('submit_keep_p',1,'Keep <p> tags in story submissions');
 INSERT INTO vars (name, value, description) VALUES ('submit_forgetip_hours','720','Hours after which a submissions\'s ipid/subnetid are forgotten; set very large to disable');
 INSERT INTO vars (name, value, description) VALUES ('submit_forgetip_maxrows','100000','Max number of rows to forget IPs of at once');
 INSERT INTO vars (name, value, description) VALUES ('submit_forgetip_minsubid','0','Minimum subid to start forgetting IP at');
@@ -1158,5 +1158,5 @@ INSERT INTO vars (name, value, description) VALUES ('utf8', '1', '1 = Use end-to
 INSERT INTO vars (name, value, description) VALUES ('writestatus','dirty','Simple Boolean to determine if homepage needs rewriting');
 INSERT INTO vars (name, value, description) VALUES ('xhtml','0','Boolean for whether we are using XHTML');
 INSERT INTO vars (name, value, description) VALUES ('days_to_count_for_modpoints', '1', 'Number of days to use in counting comments for handing out modpoints');
-INSERT INTO vars (name, value, desctiption) VALUES ('utf8_max_diacritics', '4', 'The threshold of diacritic marks on a single character at which they all get stripped off');
+INSERT INTO vars (name, value, description) VALUES ('utf8_max_diacritics', '4', 'The threshold of diacritic marks on a single character at which they all get stripped off');
 INSERT INTO vars (name, value, description) VALUES ("downmod_karma_floor", "10", "Below this level of karma, users cannot use negative moderations");

--- a/sql/mysql/slashschema_create.sql
+++ b/sql/mysql/slashschema_create.sql
@@ -75,7 +75,7 @@ CREATE TABLE accesslog_admin (
 	PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-DROP TABLE IF EXISTS accesslog_artcom;
+DROP TABLE IF EXISTS ajax_ops;
 CREATE TABLE ajax_ops (
 	id mediumint(5) unsigned NOT NULL AUTO_INCREMENT,
 	op varchar(50) NOT NULL DEFAULT '',
@@ -87,7 +87,7 @@ CREATE TABLE ajax_ops (
 	UNIQUE KEY op (op)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-DROP TABLE IF EXISTS ajax_ops;
+DROP TABLE IF EXISTS accesslog_artcom;
 CREATE TABLE accesslog_artcom (
 	uid mediumint UNSIGNED NOT NULL,
 	ts datetime NOT NULL DEFAULT '1970-01-01 00:00:00',

--- a/sql/mysql/slashschema_create.sql
+++ b/sql/mysql/slashschema_create.sql
@@ -76,6 +76,18 @@ CREATE TABLE accesslog_admin (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 DROP TABLE IF EXISTS accesslog_artcom;
+CREATE TABLE ajax_ops (
+	id mediumint(5) unsigned NOT NULL AUTO_INCREMENT,
+	op varchar(50) NOT NULL DEFAULT '',
+	class varchar(100) NOT NULL DEFAULT '',
+	subroutine varchar(100) NOT NULL DEFAULT '',
+	reskey_name varchar(64) NOT NULL DEFAULT '',
+	reskey_type varchar(64) NOT NULL DEFAULT '',
+	PRIMARY KEY (`id`),
+	UNIQUE KEY op (op)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+DROP TABLE IF EXISTS ajax_ops;
 CREATE TABLE accesslog_artcom (
 	uid mediumint UNSIGNED NOT NULL,
 	ts datetime NOT NULL DEFAULT '1970-01-01 00:00:00',

--- a/sql/mysql/slashschema_create.sql
+++ b/sql/mysql/slashschema_create.sql
@@ -1563,6 +1563,7 @@ CREATE TABLE users_info (
 	people MEDIUMBLOB,
 	lastaccess_ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
         skin varchar(255) DEFAULT NULL,
+        mod_banned date DEFAULT '1000-01-01',
 	PRIMARY KEY (uid),
 	KEY (initdomain),
 	KEY (created_ipid),

--- a/sql/mysql/slashschema_create.sql
+++ b/sql/mysql/slashschema_create.sql
@@ -1472,15 +1472,13 @@ CREATE TABLE users_comments (
 	clsmall smallint UNSIGNED DEFAULT '0' NOT NULL,
 	reparent tinyint DEFAULT '1' NOT NULL,
 	nosigs tinyint DEFAULT '0' NOT NULL,
-	points tinyint DEFAULT '0' NOT NULL,
 	commentlimit smallint UNSIGNED DEFAULT '100' NOT NULL,
 	commentspill smallint UNSIGNED DEFAULT '50' NOT NULL,
 	commentsort tinyint DEFAULT '0' NOT NULL,
 	noscores tinyint DEFAULT '0' NOT NULL,
 	mode ENUM('flat', 'nested', 'nocomment', 'thread','improvedthreaded') DEFAULT 'improvedthreaded' NOT NULL,
 	threshold tinyint DEFAULT '0' NOT NULL,
-	PRIMARY KEY (uid),
-	KEY points (points)
+	PRIMARY KEY (uid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 #

--- a/sql/mysql/slashschema_create.sql
+++ b/sql/mysql/slashschema_create.sql
@@ -1472,6 +1472,7 @@ CREATE TABLE users_comments (
 	clsmall smallint UNSIGNED DEFAULT '0' NOT NULL,
 	reparent tinyint DEFAULT '1' NOT NULL,
 	nosigs tinyint DEFAULT '0' NOT NULL,
+	points tinyint DEFAULT '0' NOT NULL,
 	commentlimit smallint UNSIGNED DEFAULT '100' NOT NULL,
 	commentspill smallint UNSIGNED DEFAULT '50' NOT NULL,
 	commentsort tinyint DEFAULT '0' NOT NULL,

--- a/themes/default/THEME
+++ b/themes/default/THEME
@@ -41,7 +41,6 @@ template=templates/editComm;users;default
 template=templates/editHome;users;default
 template=templates/editKey;users;default
 template=templates/editMiscOpts;users;default
-template=templates/editTags;users;default
 template=templates/editUser;users;default
 template=templates/edit_comment;comments;default
 template=templates/end_tab;misc;default

--- a/themes/default/sql/mysql/datadump.sql
+++ b/themes/default/sql/mysql/datadump.sql
@@ -343,7 +343,7 @@ INSERT INTO users (uid, nickname, realemail, fakeemail, homepage, passwd, sig, s
 # Dumping data for table 'users_comments'
 #
 
-INSERT INTO users_comments (uid, points, posttype, defaultpoints, highlightthresh, maxcommentsize, hardthresh, clbig, clsmall, reparent, nosigs, commentlimit, commentspill, commentsort, noscores, mode, threshold) VALUES (1,0,2,0,4,4096,0,0,0,1,0,50000,50,0,0,'thread',0);
+INSERT INTO users_comments (uid, posttype, defaultpoints, highlightthresh, maxcommentsize, hardthresh, clbig, clsmall, reparent, nosigs, commentlimit, commentspill, commentsort, noscores, mode, threshold) VALUES (1,2,0,4,4096,0,0,0,1,0,50000,50,0,0,'thread',0);
 
 #
 # Dumping data for table 'users_hits'


### PR DESCRIPTION
Included: Some fixes for SQL issues, a few minor make changes. After patched, default minimal Debian 8 installation works following `perldoc INSTALL`. Commits that warranted, are commented.