### PR TITLE
Should fix TNG TLCs ignoring Breakthrough

### DIFF
--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -1252,7 +1252,7 @@ sub displayThread {
 		$below = "";
 		$visible = 0;
 		my $show = 0;
-		if((defined($form->{cid}) && $comments->{$cid}->{pid} == $form->{cid}) || ($user->{mode} ne 'threadtos' && $pid == 0)) { $show = 1; }
+		if(defined($form->{cid}) && $comments->{$cid}->{pid} == $form->{cid}) { $show = 1; }
 
 		$skipped++;
 		# since threaded shows more comments, we can skip


### PR DESCRIPTION
Forgot I had even special cased them to be always visible. Removing code to fix a bug instead of adding it is always nice.