### PR TITLE
Black bg for linkCommentPage on vt100/vt220

### DIFF
--- a/themes/vt100/htdocs/vt100.cssraw
+++ b/themes/vt100/htdocs/vt100.cssraw
@@ -184,8 +184,11 @@ input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a,
     border-bottom: 1px solid #0f0;
 }
 
-
 .commentBox { background: #181818; }
+
+.linkCommentPage {
+	background: #000;
+}
 
 
 /* FORMTABS */

--- a/themes/vt220/htdocs/vt220.cssraw
+++ b/themes/vt220/htdocs/vt220.cssraw
@@ -184,8 +184,11 @@ input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a,
     border-bottom: 1px solid #ffc200;
 }
 
-
 .commentBox { background: #181818; }
+
+.linkCommentPage {
+	background: #000;
+}
 
 
 /* FORMTABS */


### PR DESCRIPTION
Hello, I'm proposing this small patch that sets a black background for the comment page numbers area on vt100/vt220 themes. Currently it is rendered as a medium gray rectangle, which is in sharp contrast to the rest of the theme. Thanks!