### PR TITLE
Fix bug preventing fractional-dollar bitcoin payments

### DIFF
--- a/plugins/Subscribe/subscribe.pl
+++ b/plugins/Subscribe/subscribe.pl
@@ -331,7 +331,7 @@ sub stripe {
 	}
 
 	my $tx = {
-		amount			=> int(sprintf("%.2d", $form->{amount}) * 100),
+		amount			=> int($form->{amount} * 100),
 		description		=> $constants->{sitename}." subscription payment",
 		currency		=> defined $constants->{stripe_currency} ? $constants->{stripe_currency} : "USD",
 		'metadata[uid]'		=> $cryptValues->{uid},


### PR DESCRIPTION
I believe the sprintf() format argument was a typing error (should have been "%.2f" rather than "%.2d").

With "%.2d", the fractional amount is dropped before the multiplication so if you entered a fractional amount, it would be rounded down to the nearest dollar. Stripe would then reject it as it doesn't match the other copy of the amount it had (with the intact fraction).

This change resolves this issue and removes the unnecessary sprintf().