### PR TITLE
Should print the proper date for updated subs now

### DIFF
--- a/plugins/Subscribe/subscribe.pl
+++ b/plugins/Subscribe/subscribe.pl
@@ -107,7 +107,7 @@ sub edit {
 			$user_edit = $slashdb->getUser($slashdb->getUserUID($id));
 		}
 	} else {
-		$user_edit = $user;
+		$user_edit = $slashdb->getUser($user->{uid});
 	}
 	
 	my $admin_block = 	slashDisplay('getUserAdmin', {

--- a/themes/default/htdocs/users.pl
+++ b/themes/default/htdocs/users.pl
@@ -406,7 +406,12 @@ sub main {
 
 	if($op eq "savehome") {
 		$ops->{$op}->{function}->();
-		redirect($constants->{real_rootdir}."/my/homepage");
+		if($user->{is_admin} && $form->{uid} != $user->{uid}) {
+			redirect($constants->{real_rootdir}."/users.pl?op=admin&uid=$form->{uid}");
+		}
+		else {
+			redirect($constants->{real_rootdir}."/my/homepage");
+		}
 		return;
 	}
 

--- a/themes/default/htdocs/users.pl
+++ b/themes/default/htdocs/users.pl
@@ -3015,7 +3015,6 @@ sub saveHome {
 	}
 
 	#editHome({ uid => $uid, note => $note });
-	redirect("$constants->{real_rootdir}/users.pl?op=userEdit", 301);
 }
 
 #################################################################

--- a/themes/default/htdocs/users.pl
+++ b/themes/default/htdocs/users.pl
@@ -404,6 +404,12 @@ sub main {
 		return;
 	}
 
+	if($op eq "savehome") {
+		$ops->{$op}->{function}->();
+		redirect($constants->{real_rootdir}."/my/homepage");
+		return;
+	}
+
 	# Print the header and very top stuff on the page.  We have
 	# three ops that (may) end up routing into showInfo(), which
 	# needs to do some stuff before it calls header(), so for
@@ -3008,7 +3014,8 @@ sub saveHome {
 		$slashdb->setUser($uid, $user_edits_table);
 	}
 
-	editHome({ uid => $uid, note => $note });
+	#editHome({ uid => $uid, note => $note });
+	redirect("$constants->{real_rootdir}/users.pl?op=userEdit", 301);
 }
 
 #################################################################


### PR DESCRIPTION
The value of getCurrentUser is fixed at script initialization. We don't add days until well after that though and then do the displaying, so a fresh copy of $user is needed.