### PR TITLE
Improvements to "Purchase Subscription" form

### DIFF
--- a/plugins/Subscribe/PLUGIN
+++ b/plugins/Subscribe/PLUGIN
@@ -17,3 +17,4 @@ template=templates/paypalsubbut;subscribe;default
 template=templates/sub_low_msg;misc;default
 template=templates/sub_out_msg;misc;default
 template=templates/stripebut;subscribe;default
+template=templates/purchaseform;subscribe;default

--- a/plugins/Subscribe/templates/acsub;subscribe;default
+++ b/plugins/Subscribe/templates/acsub;subscribe;default
@@ -16,7 +16,7 @@ __template__
 	[% PROCESS userboxes %]
 </div>
 <div id="users-blocks">
-	[% PROCESS titlebar title => 'Purcase Gift Subscription' %]
+	[% PROCESS titlebar title => 'Purchase Gift Subscription' %]
 	<div class="generalbody">
 	
 		[% IF note %]

--- a/plugins/Subscribe/templates/acsub;subscribe;default
+++ b/plugins/Subscribe/templates/acsub;subscribe;default
@@ -25,24 +25,8 @@ __template__
 			</div>
 		[% END %]
 		
-		<form method="post" action="[% constants.real_rootdir %]/subscribe.pl">
-			<fieldset>
-				You can buy a gift subscription for another user. Payments are handled by Stripe (for credit card payments and BitCoin) and PayPal (for PayPal payments and credit cards). The recipient of a gift subscription will be notified of your purchase through email. Information about subscriptions can be found in the <a href="/faq.pl?op=subscribe">Why Subscribe FAQ</a>.<br />
-				<br />
-				<input type="hidden" name="subscription_type" value="gift">
-				Buy Gift Subscription for UID <input type="text" name="uid" size="10" value="[% constants.subscribe_ac_default_gift %]"><br />	
-				<br />
-				Who do you want the recipient to be told the gift is from?<br />
-				<input type="text" name="from" size="35" maxlength="35" value="[% constants.anon_name_alt %]" > (35 character limit)<br />
-				<p><b>Duration and price:</b> Choose a subscription duration and set the price you wish to pay for it. Defaults are the minimum for that duration but you can support SoylentNews even more, if you'd like to, by increasing the amount.</p>
-				<input type="radio" name="subscription_days" value="[% constants.subscribe_monthly_days %]"> [% constants.subscribe_monthly_days %] Day: <input type="text" name="monthly_amount" size="7" maxlength="7" value="[% constants.subscribe_monthly_amount %]"> USD<br />
-				<input type="radio" name="subscription_days" value="[% constants.subscribe_semiannual_days %]"> [% constants.subscribe_semiannual_days %] Day: <input type="text" name="semiannual_amount" size="7" maxlength="7" value="[% constants.subscribe_semiannual_amount %]"> USD<br />
-				<input type="radio" name="subscription_days" value="[% constants.subscribe_annual_days %]" checked="checked"> [% constants.subscribe_annual_days %] Day: <input type="text" name="annual_amount" size="7" maxlength="7" value="[% constants.subscribe_annual_amount %]"> USD<br />
-				<br />
-				<input type="hidden" name="op" value="confirm"><input type="submit" value="Continue">
-			</fieldset>
-		</form>
-			
+		[% PROCESS purchaseform %]
+
 		<p>If you have any questions or concerns about billing, or other subscription-related issues, please contact <a href="mailto:[% constants.subscribe_email %]">[%constants.subscribe_email %]</a>.</p>
 	</div>
 </div>

--- a/plugins/Subscribe/templates/confirm;subscribe;default
+++ b/plugins/Subscribe/templates/confirm;subscribe;default
@@ -60,7 +60,7 @@ __template__
 				[% END %]
 			[% END %]
 		[% ELSE %]
-			<p class='error'>Recognized subscription type not selected.</p>
+			<p class='error'>The subscription type was not recognized. Did you forget to select one?</p>
 		[% END %]
 	</div>
 </div>

--- a/plugins/Subscribe/templates/edit;subscribe;default
+++ b/plugins/Subscribe/templates/edit;subscribe;default
@@ -62,27 +62,7 @@ __template__
 		[% END %]
 	
 		[% IF user.uid == user_edit.uid %]	
-			<form method="post" action="[% constants.real_rootdir %]/subscribe.pl">
-				<fieldset>
-					<legend>Purchase Subscriptions</legend>
-					You can buy a subscription for yourself or a gift subscription for another user. Payments are handled by Stripe (for credit card payments and BitCoin) and PayPal (for PayPal payments and credit cards). The recipient of a gift subscription will be notified of your purchase through email. Information about subscriptions can be found in the <a href="[% constants.real_rootdir %]/faq.pl?op=subscribe">Why Subscribe FAQ</a>.<br />
-					
-					<br />
-					<input type="radio" name="subscription_type" value="user"> Buy Subscription for [% user.nickname | strip_literal %]<br />
-					<input type="radio" name="subscription_type" value="gift"> Buy Gift Subscription for UID <input type="text" name="uid" size="10"><br />	
-					<br />
-					
-					For gift subscriptions only:<br />
-					Who do you want the recipient to be told the gift is from?<br />
-					<input type="text" name="from" size="35" maxlength="35"> (35 character limit, defaults to your username if nothing is entered)<br />
-					<p><b>Duration and price:</b> Choose a subscription duration and set the price you wish to pay for it. Defaults are the minimum for that duration but you can support SoylentNews even more, if you'd like to, by increasing the amount.</p>
-					<input type="radio" name="subscription_days" value="[% constants.subscribe_monthly_days %]"> [% constants.subscribe_monthly_days %] Day: <input type="text" name="monthly_amount" size="7" maxlength="7" value="[% constants.subscribe_monthly_amount %]"> USD<br />
-					<input type="radio" name="subscription_days" value="[% constants.subscribe_semiannual_days %]"> [% constants.subscribe_semiannual_days %] Day: <input type="text" name="semiannual_amount" size="7" maxlength="7" value="[% constants.subscribe_semiannual_amount %]"> USD<br />
-					<input type="radio" name="subscription_days" value="[% constants.subscribe_annual_days %]" checked="checked"> [% constants.subscribe_annual_days %] Day: <input type="text" name="annual_amount" size="7" maxlength="7" value="[% constants.subscribe_annual_amount %]"> USD<br />
-					<br />
-					<input type="hidden" name="op" value="confirm"><input type="submit" value="Continue">
-				</fieldset>
-			</form>
+			[% PROCESS purchaseform %]
 		[% END %]
 
 		[% IF user.is_admin %]

--- a/plugins/Subscribe/templates/purchaseform;subscribe;default
+++ b/plugins/Subscribe/templates/purchaseform;subscribe;default
@@ -1,0 +1,80 @@
+__section__
+default
+__description__
+This template provides a (login sensitive) form for purchasing subscriptions.
+__title__
+purchaseform;subscribe;default
+__page__
+subscribe
+__lang__
+en_US
+__name__
+purchaseform
+__seclev__
+10000
+__template__
+<form method="post" action="[% constants.real_rootdir %]/subscribe.pl">
+	<fieldset class="purchasesubscription">
+	[% IF !user.is_anon %]
+		<legend>Purchase Subscription</legend>
+	[% END %]
+
+		<p>
+		[% IF user.is_anon %]
+			You can gift a subscription to another user.
+		[% ELSE %]
+			You can buy a subscription for yourself, or gift one to another user.
+		[% END %]
+			Payment is handled by Stripe (credit card/BitCoin) or PayPal (credit card/PayPal).
+			Information about subscriptions can be found in the <a href="/faq.pl?op=subscribe">Why Subscribe FAQ</a>.
+		</p>
+		<ul class="purchasesubscription__type">
+		[% IF !user.is_anon %]
+			<li>
+				<input type="radio" name="subscription_type" value="user">
+				Buy Subscription for [% user.nickname | strip_literal %]
+			</li>
+		[% END %]
+			<li>
+			[% IF user.is_anon %]
+				<input type="radio" name="subscription_type" value="gift" checked="checked">
+			[% ELSE %]
+				<input type="radio" name="subscription_type" value="gift">
+			[% END %]
+				Buy Gift Subscription for UID <input type="text" name="uid" size="10" value="[% constants.subscribe_ac_default_gift %]">
+			</li>
+		</ul>
+		<p>
+			The recipient of a gift subscription will be notified of your purchase through email.
+			Who do you want the recipient to be told the gift is from?
+			<input type="text" name="from" size="35" maxlength="35" value="[% user.nickname %]">
+			(35 character limit)
+		</p>
+		<p>
+			<b>Duration and price:</b> Choose a subscription duration and set the price you wish to pay for it.
+			Defaults are the minimum for that duration but you can support SoylentNews even more, if you'd like to, by increasing the amount.
+		</p>
+		<ul class="purchasesubscription__duration">
+			<li>
+				<input type="radio" name="subscription_days" value="[% constants.subscribe_monthly_days %]">
+				<span>[% constants.subscribe_monthly_days %] Day:</span>
+				<input type="text" name="monthly_amount" size="7" maxlength="7" value="[% constants.subscribe_monthly_amount %]">
+				<span>USD</span>
+			</li>
+			<li>
+				<input type="radio" name="subscription_days" value="[% constants.subscribe_semiannual_days %]">
+				<span>[% constants.subscribe_semiannual_days %] Day:</span>
+				<input type="text" name="semiannual_amount" size="7" maxlength="7" value="[% constants.subscribe_semiannual_amount %]">
+				<span>USD</span>
+			</li>
+			<li>
+				<input type="radio" name="subscription_days" value="[% constants.subscribe_annual_days %]" checked="checked">
+				<span>[% constants.subscribe_annual_days %] Day:</span>
+				<input type="text" name="annual_amount" size="7" maxlength="7" value="[% constants.subscribe_annual_amount %]">
+				<span>USD</span>
+			</li>
+		</ul>
+		<input type="hidden" name="op" value="confirm">
+		<input type="submit" value="Continue">
+	</fieldset>
+</form>

--- a/themes/default/htdocs/base.css
+++ b/themes/default/htdocs/base.css
@@ -1118,3 +1118,30 @@ body blockquote.spoiler {
 #sabutton {
 	display: none;
 }
+
+.purchasesubscription legend + p {
+	margin-top: 0;
+}
+
+.purchasesubscription__type, .purchasesubscription__duration {
+	list-style: none;
+	padding: 0;
+	margin: 0:
+}
+
+.purchasesubscription__duration {
+	display: table;
+}
+
+.purchasesubscription__duration li {
+	display: table-row;
+}
+
+.purchasesubscription__duration li input, .purchasesubscription__duration li span {
+	text-align: right;
+}
+
+.purchasesubscription__duration li input, .purchasesubscription__duration li span {
+	display: table-cell;
+	padding: 0 0.2em;
+}


### PR DESCRIPTION
These commits fix a typing error, improves the error message when the subscription type isn't recognised (usually because one hasn't been selected) and separates the form into its own template (which removes a lot of duplicated text and code).

The format of the form has also been changed so that elements are lined up (look much neater, in my opinion) and the HTML should more appropriate.