### PR TITLE
Remove illegal <p>-within-<span> nesting

### DIFF
--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -2342,7 +2342,7 @@ sub printCommComments {
 	$html_out .= $args->{lcp}."<div id=\"discussion_buttons\">\n";
 	
 	if(!$user->{state}->{discussion_archived} && !$user->{state}->{discussion_future_nopost}) {
-		$html_out .= "<span class=\"nbutton\"><p><b>".
+		$html_out .= "<span class=\"nbutton\"><b>".
 		linkComment({
 			sid => $args->{sid},
 			cid => $args->{cid},
@@ -2350,14 +2350,14 @@ sub printCommComments {
 			subject => 'Reply',
 			subject_only => 1
 		}).
-		"</b></p></span>\n";
+		"</b></span>\n";
 	}
 
 	if(!$user->{is_anon}) {
-		$html_out .= "<span class=\"nbutton\"><p><b><a href=\"$gSkin->{rootdir}/my/comments\">Prefs</a></b></p></span>\n";
+		$html_out .= "<span class=\"nbutton\"><b><a href=\"$gSkin->{rootdir}/my/comments\">Prefs</a></b></span>\n";
 	}
 
-	$html_out .= "<span class=\"nbutton\"><p><b><a href=\"$gSkin->{rootdir}/faq.pl?op=moderation\">Moderator Help</a></b></p></span>\n";
+	$html_out .= "<span class=\"nbutton\"><b><a href=\"$gSkin->{rootdir}/faq.pl?op=moderation\">Moderator Help</a></b></span>\n";
 
 	if($moderate_form) {
 		$html_out .= "<input type=\"hidden\" name=\"op\" value=\"moderate\">\n";
@@ -2366,7 +2366,7 @@ sub printCommComments {
 		$html_out .= "<input type=\"hidden\" name=\"pid\" value=\"$args->{pid}\">\n" if $args->{pid};
 		$html_out .= "<button type=\"submit\" name=\"moderate\" value=\"discussion_buttons\">Moderate</button>\n";
 		if($can_del) {
-			$html_out .= "<span class=\"nbutton\"><p><b><a href=\"#\" onclick=\"\$('#commentform').submit(); return false\">Delete</a></b></p></span>\nChecked comments will be deleted!";
+			$html_out .= "<span class=\"nbutton\"><b><a href=\"#\" onclick=\"\$('#commentform').submit(); return false\">Delete</a></b></span>\nChecked comments will be deleted!";
 		}
 
 	}
@@ -2699,7 +2699,7 @@ sub dispLinkComment {
 	}
 	if(!$args->{options}->{pieces}) {
 		if(!$user->{state}->{discussion_archived} && !$user->{state}->{discussion_future_nopost}) {
-			$html_out .= "<span id=\"reply_link_$args->{cid}\" class=\"nbutton\"><p><b>".
+			$html_out .= "<span id=\"reply_link_$args->{cid}\" class=\"nbutton\"><b>".
 				linkComment({
 					sid => $args->{sid},
 					pid => $args->{pid},
@@ -2707,17 +2707,17 @@ sub dispLinkComment {
 					op => 'Reply',
 					subject => 'Reply to This',
 					subject_only => 1,
-				})."</b></p></span> \n";
+				})."</b></span> \n";
 		}
 		if($do_parent) {
-			$html_out .= "<span class=\"nbutton\"><p><b>".
+			$html_out .= "<span class=\"nbutton\"><b>".
 				linkComment({
 					sid => $args->{sid},
 					cid => $do_parent,
 					pid => $do_parent,
 					subject => 'Parent',
 					subject_only => 1,
-				}, 1)."</b></p></span> \n";
+				}, 1)."</b></span> \n";
 		}
 		if($args->{can_mod}) {
 			$html_out .= "<div id=\"reasondiv_$args->{cid}\" class=\"modsel\">\n"

--- a/plugins/Ajax/templates/edit_comment;ajax;default
+++ b/plugins/Ajax/templates/edit_comment;ajax;default
@@ -61,19 +61,19 @@ in now</a>, or <a href="[% gSkin.rootdir %]/users.pl">Create an Account</a>.
 		<div id="replyto_msg_[% pid %]" class="replyto_msg" style="display: none"></div>
 		<div class="replyto_buttons">
 			<span id="replyto_buttons_1_[% pid %]">
-				<span id="preview_[% pid %]" class="nbutton"><p><b><a href="#" onclick="D2.previewReply([% pid %]); return false;">Preview</a></b></p></span>
+				<span id="preview_[% pid %]" class="nbutton"><b><a href="#" onclick="D2.previewReply([% pid %]); return false;">Preview</a></b></span>
 				[%- IF pid # not for root-level reply %]
-				<span id="quotereply_[% pid %]" class="nbutton"><p><b><a href="#" onclick="D2.quoteReply([% pid %]); return false;">Quote Parent</a></b></p></span>[% END %]
+				<span id="quotereply_[% pid %]" class="nbutton"><b><a href="#" onclick="D2.quoteReply([% pid %]); return false;">Quote Parent</a></b></span>[% END %]
 				[%- UNLESS user.is_anon %]
-				<span id="prefs_[% pid %]" class="nbutton"><p><b><a href="#" onclick="getModalPrefs('d2_posting', 'Discussion 2', 1); return false;">Options</a></b></p></span>[% END %]
+				<span id="prefs_[% pid %]" class="nbutton"><b><a href="#" onclick="getModalPrefs('d2_posting', 'Discussion 2', 1); return false;">Options</a></b></span>[% END %]
 			</span>
 			<span id="replyto_buttons_2_[% pid %]" style="display: none">
-				<span id="submit_[% pid %]" class="nbutton"><p><b><a href="#" onclick="D2.submitReply([% pid %]); return false;">Submit<span id="submit_countdown_[% pid %]"></span></a></b></p></span>
-				<span id="edit_[% pid %]" class="nbutton"><p><b><a href="#" onclick="D2.editReply([% pid %]); return false;">Continue Editing</a></b></p></span>
+				<span id="submit_[% pid %]" class="nbutton"><b><a href="#" onclick="D2.submitReply([% pid %]); return false;">Submit<span id="submit_countdown_[% pid %]"></span></a></b></span>
+				<span id="edit_[% pid %]" class="nbutton"><b><a href="#" onclick="D2.editReply([% pid %]); return false;">Continue Editing</a></b></span>
 				<span class="state">Preview</span>
 			</span>
 			<span id="replyto_buttons_3_[% pid %]">
-				<span id="cancel_[% pid %]" class="nbutton"><p><b><a href="#" onclick="D2.cancelReply([% pid %]); return false;">Cancel</a></b></p></span>
+				<span id="cancel_[% pid %]" class="nbutton"><b><a href="#" onclick="D2.cancelReply([% pid %]); return false;">Cancel</a></b></span>
 			</span>
 		</div>
 	</form>

--- a/themes/default/htdocs/comments.cssraw
+++ b/themes/default/htdocs/comments.cssraw
@@ -310,13 +310,11 @@ ul#commentlisting
 	background: none;
 	margin:0;
 	white-space: nowrap;
-}
-.nbutton p{
 	display:inline;
 	padding: 0 0;
 }
 
-.nbutton p b a {
+.nbutton b a {
 	background: #555;
 	border-radius: .3em;
 	text-align:center;

--- a/themes/default/htdocs/slashcode_lite.cssraw
+++ b/themes/default/htdocs/slashcode_lite.cssraw
@@ -7,7 +7,7 @@ div#footer a,
 div.btmnav a
 { color: #00E !important; text-decoration: underline !important;}
 
-input[type=submit], .logout  a, div.storylinks ul li.more a, .nbutton p b a {
+input[type=submit], .logout  a, div.storylinks ul li.more a, .nbutton b a {
     color:#fff !important;
     text-decoration:none !important;
 }

--- a/themes/default/templates/dispLinkComment;misc;default
+++ b/themes/default/templates/dispLinkComment;misc;default
@@ -20,22 +20,22 @@ __template__
 		[% IF !options.show_pieces %]<div class="commentSub" id="comment_sub_[% cid %]">[% END; IF !options.pieces %]
 
 		[% IF !user.state.discussion_archived && !user.state.discussion_future_nopost %]
-			<span id="reply_link_[% cid %]" class="nbutton"><p><b>[% Slash.linkComment({
+			<span id="reply_link_[% cid %]" class="nbutton"><b>[% Slash.linkComment({
 				sid	=> sid,
 				pid	=> cid,
 				op	=> 'Reply',
 				subject	=> 'Reply to This',
 				subject_only => 1,
-			}) %]</b></p></span>
+			}) %]</b></span>
 		[% END %]
 
-		[% IF do_parent %]<span class="nbutton"><p><b>[% Slash.linkComment({
+		[% IF do_parent %]<span class="nbutton"><b>[% Slash.linkComment({
 			sid	=> sid,
 			cid	=> original_pid,
 			pid	=> original_pid,
 			subject	=> 'Parent',
 			subject_only => 1,
-		}, 1) %]</b></p></span>[% END %]
+		}, 1) %]</b></span>[% END %]
 		
 		[% IF can_mod %]
 		

--- a/themes/default/templates/printCommComments;misc;default
+++ b/themes/default/templates/printCommComments;misc;default
@@ -85,20 +85,20 @@ __template__
 <div id="discussion_buttons">
 
 [% IF !user.state.discussion_archived && !user.state.discussion_future_nopost %]
-<span class="nbutton"><p><b>[% Slash.linkComment({
+<span class="nbutton"><b>[% Slash.linkComment({
 	sid          => sid,
 	cid          => cid,
 	op           => 'reply',
 	subject      => 'Reply',
 	subject_only => 1,
-}) %]</b></p></span>
+}) %]</b></span>
 [% END %]
 
 [% IF !user.is_anon %]
-<span class="nbutton"><p><b><a href="[% gSkin.rootdir %]/my/comments">Prefs</a></b></p></span>[% END %]
+<span class="nbutton"><b><a href="[% gSkin.rootdir %]/my/comments">Prefs</a></b></span>[% END %]
 
 [% IF (can_moderate || user.acl.candelcomments_always) %]
-<span class="nbutton"><p><b><a href="[% gSkin.rootdir %]/faq.pl?op=moderation">Moderator Help</a></b></p></span>[% END %]
+<span class="nbutton"><b><a href="[% gSkin.rootdir %]/faq.pl?op=moderation">Moderator Help</a></b></span>[% END %]
 
 [% IF moderate_form %]
 	[% IF moderate_button %]
@@ -108,7 +108,7 @@ __template__
 		<input type="hidden" name="pid" value="[% pid %]">
 		<button type="submit" name="moderate" value="discussion_buttons">Moderate</button>
 		[% IF can_del %]
-			<span class="nbutton"><p><b><a href="#" onclick="$('#commentform').submit(); return false">Delete</a></b></p></span>
+			<span class="nbutton"><b><a href="#" onclick="$('#commentform').submit(); return false">Delete</a></b></span>
 			Checked comments will be deleted!
 		[% END %]
 	[% END %]

--- a/themes/default/templates/printCommentsMain;misc;default
+++ b/themes/default/templates/printCommentsMain;misc;default
@@ -141,19 +141,19 @@ __template__
 				[% IF pid %]<input type="hidden" name="pid" value="[% pid %]">[% END %]
 				[% IF form.startat %]<input type="hidden" name="startat" value="[% form.startat %]">[% END %]
 				[% UNLESS user.state.discussion_archived || user.state.discussion_future_nopost %]
-					<span class="nbutton"><p><b>[% Slash.linkComment({
+					<span class="nbutton"><b>[% Slash.linkComment({
 						sid          => sid,
 						pid          => cid,
 						op           => 'reply',
 						subject      => reply,
 						subject_only => 1,
-					}) %]</b></p></span>
+					}) %]</b></span>
 				[% END %]
-				 <span class="nbutton"><p><b><a href="[% stripped_link %]">Mark All as Read</a></b></p></span>
+				 <span class="nbutton"><b><a href="[% stripped_link %]">Mark All as Read</a></b></span>
 				[% IF parent.type == 'journal' %]
-						<span class="nbutton"><p><b><a href="[% stripped_link %]?markunread=1">Mark All as Unread</a></b></p></span>
+						<span class="nbutton"><b><a href="[% stripped_link %]?markunread=1">Mark All as Unread</a></b></span>
 				[% ELSE %]
-						<span class="nbutton"><p><b><a href="[% stripped_link %]&markunread=1">Mark All as Unread</a></b></p></span>
+						<span class="nbutton"><b><a href="[% stripped_link %]&markunread=1">Mark All as Unread</a></b></span>
 				[% END %]
 			</fieldset>
 		</form>

--- a/themes/grayscale/htdocs/grayscale.cssraw
+++ b/themes/grayscale/htdocs/grayscale.cssraw
@@ -354,7 +354,7 @@ div.storylinks ul li
 .story_main { background: #ccc;}
 
 
-input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton p b a, .nbutton p b a:hover
+input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton b a, .nbutton b a:hover
 {
 	background-color: #666;
 }

--- a/themes/night/htdocs/night.cssraw
+++ b/themes/night/htdocs/night.cssraw
@@ -332,7 +332,7 @@ div.storylinks ul li
 .story_main { background: #ccc;}
 
 
-input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton p b a, .nbutton p b a:hover
+input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton b a, .nbutton b a:hover
 {
 	background-color: #666;
 }

--- a/themes/pwnies/htdocs/pwnies.cssraw
+++ b/themes/pwnies/htdocs/pwnies.cssraw
@@ -36,7 +36,7 @@ a:hover { color: #ea97bc; }
 	font-weight: bold;
 }
 
-input[type="submit"], button[type=submit], .logout a, div.storylinks ul li.more a, .nbutton p b a  {
+input[type="submit"], button[type=submit], .logout a, div.storylinks ul li.more a, .nbutton b a  {
 	background: none repeat scroll 0% 0% #c5618e;
 }
 

--- a/themes/vt100/htdocs/vt100.cssraw
+++ b/themes/vt100/htdocs/vt100.cssraw
@@ -59,7 +59,7 @@ hr {
 color: #0c0;
 }
 
-input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton p b a, .nbutton p b a:hover
+input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton b a, .nbutton b a:hover
 {
 	background: none repeat scroll 0% 0% #333; !important;
 	color: #0f0 !important;
@@ -541,7 +541,7 @@ color: #0c0;
 	color: #0f0;
 }
 
-.nbutton p b a {
+.nbutton b a {
 	color: #0f0 !important;
 	background: none repeat scroll 0% 0% #333 !important;
 }

--- a/themes/vt220/htdocs/vt220.cssraw
+++ b/themes/vt220/htdocs/vt220.cssraw
@@ -59,7 +59,7 @@ hr {
 color: #ffa200;
 }
 
-input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton p b a, .nbutton p b a:hover
+input[type=submit], button[type=submit], .logout a, div.storylinks ul li.more a, input[type=submit]:hover, button[type=submit]:hover, .logout a:hover, div.storylinks ul li.more a:hover, .nbutton b a, .nbutton b a:hover
 {
 	background: none repeat scroll 0% 0% #333; !important;
 	color: #ffc200 !important;
@@ -541,7 +541,7 @@ color: #ffa200;
 	color: #ffc200;
 }
 
-.nbutton p b a {
+.nbutton b a {
 	color: #ffc200 !important;
 	background: none repeat scroll 0% 0% #333 !important;
 }


### PR DESCRIPTION
&lt;span> elements are only permitted to contain gramattically-defined-as-inline
elements, which excludes &lt;p>s. Styling the &lt;p> as inline isn't enough to get
around that restriction. Fortunately, the &lt;p>s were never actually doing
anything but contain their contents, and there was nothing between the &lt;span>
and the &lt;p>'s contents, so we can remove the entire &lt;p>&lt;/p> layer in the nesting.

By hand-faking the results of this patch, the w3 html validator for page https://dev.soylentnews.org/meta/article.pl?sid=17/02/28/0021201 improved as follows:
before: Result: 	212 Errors
after: Result: 	84 Errors