### PR TITLE
Fix for Subscription Issues

### DIFF
--- a/plugins/Subscribe/subscribe.pl
+++ b/plugins/Subscribe/subscribe.pl
@@ -516,9 +516,13 @@ sub confirm {
 	# Previously we were allowing infinite or zero decimal places.
 	$amount = sprintf("%.2f", $amount);
 
-	my $uid = $form->{uid} || $user->{uid};
-	my $sub_user = $slashdb->getUser($uid);
 	my $puid = $user->{uid};
+	my $uid = $form->{uid} || $user->{uid};
+	if($type == "user")
+	{
+		$uid = $puid;
+	}
+	my $sub_user = $slashdb->getUser($uid);
 	
 	if ($uid == $constants->{anonymous_coward_uid}) {
 		my $note = "<p class='error'>" . $constants->{anon_name_alt} . " cannot recieve a subscription.  Please choose another user to gift.</p>";

--- a/plugins/Subscribe/subscribe.pl
+++ b/plugins/Subscribe/subscribe.pl
@@ -516,9 +516,10 @@ sub confirm {
 	# Previously we were allowing infinite or zero decimal places.
 	$amount = sprintf("%.2f", $amount);
 
+	# puid = paying user, uid = user getting the sub
 	my $puid = $user->{uid};
 	my $uid = $form->{uid} || $user->{uid};
-	if($type == "user")
+	if($type eq "user")
 	{
 		$uid = $puid;
 	}


### PR DESCRIPTION
I have no idea why the logic was the way it was but subscription_type "user" was not forcing the payment to go to the account paying but to whatever uid was in the gift box. Fixed.