### PR TITLE
Data.pm: Let spoilers have titles apart from *SPOILER* - untested

### DIFF
--- a/Slash/Utility/Data/Data.pm
+++ b/Slash/Utility/Data/Data.pm
@@ -1926,6 +1926,7 @@ sub apply_rehash_tags {
 
 	# spoiler tags
 	if (grep /^spoiler$/i, @{$constants->{approvedtags}}) {
+		# spoiler:type needs to be added to approvedtags_attr in the vars table for spoilers to work
 		my $spoiler	= 'spoiler';
 		my $open	= qr[\n* <\s* $spoiler (?:\s+type=(["'])([^"']+)\1)? \s*> \n*]xsio;
 		my $close	= qr[\n* <\s* /$spoiler \s*> \n*]xsio;

--- a/Slash/Utility/Data/Data.pm
+++ b/Slash/Utility/Data/Data.pm
@@ -1927,10 +1927,10 @@ sub apply_rehash_tags {
 	# spoiler tags
 	if (grep /^spoiler$/i, @{$constants->{approvedtags}}) {
 		my $spoiler	= 'spoiler';
-		my $open	= qr[\n* <\s*  $spoiler \s*> \n*]xsio;
+		my $open	= qr[\n* <\s* $spoiler (?:\s+type=(["'])([^"']+)\1)? \s*> \n*]xsio;
 		my $close	= qr[\n* <\s* /$spoiler \s*> \n*]xsio;
 
-		$str =~ s/$open/_newSpoilerHead()/ge;
+		$str =~ s{$open}{_newSpoilerHead($2//'SPOILER')}ge;
 		$str =~ s/$close/<\/div><\/blockquote>/g;
 	}
 
@@ -1942,8 +1942,8 @@ sub _newSpoilerHead {
 	my $id = sprintf("%08X", rand(0xFFFFFFFF));
 		
 	my $open_new = "<blockquote class=\"spoiler\"><input id=\"spoiler_$id\" type=\"checkbox\" class=\"spoiler\" autocomplete=\"off\"/>\n" .
-									"<label class=\"spoiler_off\" title=\"Show spoiler\" for=\"spoiler_$id\">*SPOILER* (click to show)</label>\n" .
-									"<label class=\"spoiler_on\" title=\"Hide spoiler\" for=\"spoiler_$id\">*SPOILER* (click to hide)</label>\n" .
+									"<label class=\"spoiler_off\" title=\"Show spoiler\" for=\"spoiler_$id\">*$_[0]* (click to show)</label>\n" .
+									"<label class=\"spoiler_on\" title=\"Hide spoiler\" for=\"spoiler_$id\">*$_[0]* (click to hide)</label>\n" .
 									"<div class=\"spoiler_text\">";
 
 	return $open_new;


### PR DESCRIPTION
Basically it should let you type
  <spoiler type="previous stories">... links ... </spoiler>
and instead of a hideable *SPOILER* block, you'd get a hideable
  *previous stories*
block.

Signed-off-by: Phil Carmody <pc+dev@asdf.org>