### PR TITLE
Poorly placed GROUP BY

### DIFF
--- a/Slash/DB/MySQL/MySQL.pm
+++ b/Slash/DB/MySQL/MySQL.pm
@@ -7538,7 +7538,7 @@ sub getStoriesEssentials {
 			# If we are excluding any topics, then add a LEFT JOIN
 			# No Left JOIN, do a sub query --paulej72
 			my $tid_x_str = join(",", @$tid_x);
-			push @stories_where, "stories.stoid NOT IN (SELECT story_topics_rendered.stoid FROM story_topics_rendered WHERE story_topics_rendered.tid IN ($tid_x_str))";
+			push @stories_where, "stories.stoid NOT IN (SELECT story_topics_rendered.stoid FROM story_topics_rendered WHERE story_topics_rendered.tid IN ($tid_x_str) GROUP BY story_topics_rendered.stoid)";
 		}
 
 		# If we'd done multiple SELECTs, this logic would have been

--- a/Slash/DB/MySQL/MySQL.pm
+++ b/Slash/DB/MySQL/MySQL.pm
@@ -7545,13 +7545,15 @@ sub getStoriesEssentials {
 		# done on the story_topics_rendered table;  as it is, these
 		# phrases have to go into the JOIN.
 		# No JOIN, do a sub query --paulej72
-		push @stories_where, "stories.stoid IN (SELECT story_topics_rendered.stoid FROM story_topics_rendered WHERE $tid_in_where)";
 
 		# The logic can return multiple story_topics_rendered rows
 		# with the same stoid, and if it does, group them together
 		# so each story only gets returned once.
-		$other = "GROUP BY stories.stoid $other";
-
+		#
+		# TMB
+		# Wouldn't it make sense to put the GROUP BY on the fucking *SUBQUERY* then?
+		# At ~25k stories it makes the goddamned difference between being a >15s query and a <0.1s query.
+		push @stories_where, "stories.stoid IN (SELECT story_topics_rendered.stoid FROM story_topics_rendered WHERE $tid_in_where GROUP BY story_topics_rendered.stoid)";
 	}
 
 	# Pull together the where clauses into one clause.


### PR DESCRIPTION
Goddamned misplaced GROUP BY was turning a <0.1s query into a >15s query.