### PR TITLE
Run portald more often

### DIFF
--- a/themes/default/tasks/run_portald.pl
+++ b/themes/default/tasks/run_portald.pl
@@ -11,7 +11,7 @@ use Slash::Constants ':slashd';
 
 use vars qw( %task $me );
 
-$task{$me}{timespec} = '37 * * * *';
+$task{$me}{timespec} = '5-59/5 * * * *';
 $task{$me}{timespec_panic_1} = ''; # not that important
 $task{$me}{fork} = SLASHD_NOWAIT;
 $task{$me}{code} = sub {


### PR DESCRIPTION
We aren't putting near enough of a load on portald to justify only running it once an hour. Changed to every five minutes so new journal entries and top comments update faster.